### PR TITLE
Corrige o problema de erro de recursão

### DIFF
--- a/cnab240/errors.py
+++ b/cnab240/errors.py
@@ -11,7 +11,7 @@ class AtribuicaoCampoError(Cnab240Error):
     def __init__(self, campo, valor):
         self.campo = campo
         self.valor = valor
-        super(AtribuicaoCampoError, self).__init__(self)
+        super(AtribuicaoCampoError, self).__init__()
 
     def __unicode__(self):
         return u'campo:{0} formato:{1} decimais:{2} digitos:{3} - valor:{4}'.\
@@ -41,7 +41,7 @@ class FaltandoArgsError(Cnab240Error):
 
     def __init__(self, args_faltantes):
         self.args_faltantes = args_faltantes
-        super(FaltandoArgsError, self).__init__(self)
+        super(FaltandoArgsError, self).__init__()
 
     def __unicode__(self):
         return (u'Os seguintes kwargs sao obrigatorios e nao foram '


### PR DESCRIPTION
Quando o pycnab lança um erro "TipoError" o odoo não consegue tratar lançando um erro de recursão.
Corrigindo o **init** da exceção resolve o problema.
