### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='cnab',
-    version='0.01',
+    name='cnab240',
+    version='0.1',
     author='Tracy Web Technologies',
     author_email='contato@tracy.com.br',
     url='https://github.com/TracyWebTech/cnab240',


### PR DESCRIPTION
without this I fail to install this with buildout and hence test or at least install Odoo modules such as:
https://github.com/kmee/odoo-brazil-banking/tree/8.0/l10n_br_cnab_import